### PR TITLE
Forzar céntimos

### DIFF
--- a/src/NumeroALetras.php
+++ b/src/NumeroALetras.php
@@ -61,7 +61,7 @@ class NumeroALetras
         'NOVECIENTOS '
     ];
 
-    public static function convertir($number, $moneda = '', $centimos = '')
+    public static function convertir($number, $moneda = '', $centimos = '', $forzarCentimos = false)
     {
         $converted = '';
         $decimales = '';
@@ -80,6 +80,9 @@ class NumeroALetras
                 $decCientos = substr($decNumberStrFill, 6);
                 $decimales = self::convertGroup($decCientos);
             }
+        }
+        else if (count($div_decimales) == 1 && $forzarCentimos){
+            $decimales = 'CERO ';
         }
 
         $numberStr = (string) $number;


### PR DESCRIPTION
Agregar la opción de desplegar `cero céntimos` para cifras enteras. Este formato es necesario por muchas entidades financieras. Ejemplos:

```php
$letras = NumeroALetras::convertir(12345, 'colones', 'centimos', true);
```

Lo cual te devuelve: DOCE MIL TRESCIENTOS CUARENTA Y CINCO COLONES CON CERO CENTIMOS