### PR TITLE
Corrección en prefijo decenas de VENTI a VEINTI

### DIFF
--- a/src/NumeroALetras.php
+++ b/src/NumeroALetras.php
@@ -38,7 +38,7 @@ class NumeroALetras
     ];
 
     private static $DECENAS = [
-        'VENTI',
+        'VEINTI',
         'TREINTA ',
         'CUARENTA ',
         'CINCUENTA ',


### PR DESCRIPTION
Corrección en decenas de VENTI a VEINTI.

Referencia: https://www.comoseescribe.net/venticinco-o-veinticinco